### PR TITLE
Fix: Secret rotation build target environment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,6 +44,6 @@ jobs:
               run: vercel pull --yes --token=${{ secrets.VERCEL_API_TOKEN }}
             - name: Build Project Artifacts
               run: |
-                  vercel build --token=${{ secrets.VERCEL_API_TOKEN }}
+                  vercel build --prod --token=${{ secrets.VERCEL_API_TOKEN }}
             - name: Deploy Project Artifacts to Vercel
-              run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_API_TOKEN }}
+              run: vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_API_TOKEN }}


### PR DESCRIPTION
The new builds which are scheduled to be pushed to Vercel via GHA were targeting the `preview` environment by default resulting in a behavior which does not update the `X_SECRET_VERSION_ID` on the production env.

`--prod` specifies the target env to be the production environment.